### PR TITLE
nebirhos: use short hostname in prompt

### DIFF
--- a/themes/nebirhos.zsh-theme
+++ b/themes/nebirhos.zsh-theme
@@ -11,7 +11,7 @@ else
 fi
 
 # Get the host name (first 4 chars)
-HOST_PROMPT_="%{$fg_bold[red]%}@$HOST ➜ %{$fg_bold[cyan]%}%c "
+HOST_PROMPT_="%{$fg_bold[red]%}@%m ➜ %{$fg_bold[cyan]%}%c "
 GIT_PROMPT="%{$fg_bold[blue]%}\$(git_prompt_info)%{$fg_bold[blue]%} % %{$reset_color%}"
 PROMPT="$HOST_PROMPT_$RUBY_PROMPT_$GIT_PROMPT"
 


### PR DESCRIPTION
Fixes #6050

## Standards checklist:

- [ ] The PR title is descriptive.
- [ ] The PR doesn't replicate another PR which is already open.
- [ ] I have read the contribution guide and followed all the instructions.
- [ ] The code follows the code style guide detailed in the wiki.
- [ ] The code is mine or it's from somewhere with an MIT-compatible license.
- [ ] The code is efficient, to the best of my ability, and does not waste computer resources.
- [ ] The code is stable and I have tested it myself, to the best of my abilities.

## Changes:

- [...]

## Other comments:

...
